### PR TITLE
feat: Conditional requests

### DIFF
--- a/src/WhatDid/GitHub.fs
+++ b/src/WhatDid/GitHub.fs
@@ -15,7 +15,7 @@ let getAllPrMergeCommitsInRange oauthToken parts =
   let isBaseRev (c: CommitListOuterObj) = c.sha.StartsWith baseRev
   let isPullMerge (c: CommitListOuterObj) = c.commit.message.StartsWith "Merge pull request #"
 
-  sprintf "https://api.github.com/repos/%s/%s/commits?sha=%s&page=1&per_page=%u" owner repo headRev perPage
+  sprintf "https://api.github.com/repos/%s/%s/commits?_base_=%s&_head_=sha&sha=%s&page=1&per_page=%u" owner repo baseRev headRev perPage
   |> Uri
   |> getPaginated oauthToken
   |> AsyncSeq.takeWhileInclusive (not << (List.exists isBaseRev))

--- a/src/WhatDid/GitHub.fs
+++ b/src/WhatDid/GitHub.fs
@@ -1,116 +1,23 @@
-module GitHub
+module GitHub.Client
 
 open FSharp.Control
 open FSharp.Control.Tasks.V2.ContextInsensitive
-open Newtonsoft.Json
+open GitHub.Types
+open GitHub.Http
 open Types
 open System
-open System.Net.Http
-open System.Net.Http.Headers
-open System.Threading.Tasks
-
-let private _httpClient =
-  let c = new HttpClient()
-  c.DefaultRequestHeaders.Add ("User-Agent", "whatdid")
-  c.DefaultRequestHeaders.Add ("Accept", "application/vnd.github.v3+json")
-  c
-
-let private _perPage = 100
-let private _createGet oauthToken (uri: Uri) =
-  let req = new HttpRequestMessage (HttpMethod.Get, uri)
-  oauthToken |> Option.iter (fun token -> req.Headers.Add ("Authorization", sprintf "token %s" token))
-  req
-let private _sendAsync request =
-  _httpClient.SendAsync (request, HttpCompletionOption.ResponseHeadersRead)
-let private _deserializeAsJsonAsync<'a> (response: HttpResponseMessage) =
-  task {
-    let! json = response.Content.ReadAsStringAsync ()
-    return JsonConvert.DeserializeObject<'a> json
-  }
-let private _tryGetAsync<'a> oauthToken uri =
-  task {
-    printfn "GET %A" uri
-    use req = _createGet oauthToken uri
-    let! response = _sendAsync req
-
-    if response.IsSuccessStatusCode then
-      let! result = _deserializeAsJsonAsync<'a> response
-      return Some result
-    else
-      return None
-  }
-
-module Temp =
-  let (|HasEverything|_|) (parts: RawParts) =
-    match parts with
-    | { owner = Some owner
-        repo = Some repo
-        baseRev = Some baseRev
-        headRev = Some headRev } -> Some (owner, repo, baseRev, headRev)
-    | _ -> None
-  let failMissingPieces (parts: RawParts) =
-    eprintfn "WARNING: Must have values for owner, repo, baseRev, headRev. %A" parts
-    exn "FIXME"
-
-open Temp
-
-type CommitListNestedObj = { message: string }
-type CommitListOuterObj = { sha: string; commit: CommitListNestedObj }
-
-module Pagination =
-  /// From GitHub docs (https://developer.github.com/v3/#pagination):
-  /// Link: <https://api.github.com/resource?page=2>; rel="next",
-  ///       <https://api.github.com/resource?page=5>; rel="last"
-  let tryGetNextUrl (headers: HttpHeaders) : Uri option =
-    "Link"
-    |> headers.GetValues
-    |> Seq.exactlyOne
-    |> fun str -> str.Split (',', StringSplitOptions.RemoveEmptyEntries)
-    |> Seq.map (fun str -> str.Trim ())
-    |> Seq.tryFind (fun str -> str.EndsWith "rel=\"next\"")
-    |> Option.map (fun str ->
-        str
-        |> Seq.skipWhile (fun ch -> ch = '<')
-        |> Seq.takeWhile (fun ch -> ch <> '>')
-        |> Seq.toArray
-        |> String
-        |> Uri
-    )
-
-  let getPaginated (reqF: Uri -> HttpRequestMessage) (deserializeAsync: HttpResponseMessage -> Task<'a list>) initialUri =
-    initialUri
-    |> Some
-    |> AsyncSeq.unfoldAsync
-        (function
-         | None -> async { return None }
-         | Some (uri: Uri) ->
-             task {
-               use req = reqF uri
-               printfn "%s %A" req.Method.Method uri
-               use! response = _sendAsync req
-               let! items = deserializeAsync response
-
-               return Some (items, tryGetNextUrl response.Headers)
-             }
-             |> Async.AwaitTask
-         )
-
-let private _getPaginated<'a> oauthToken =
-  Pagination.getPaginated
-    (_createGet oauthToken)
-    _deserializeAsJsonAsync<'a list>
 
 let getAllPrMergeCommitsInRange oauthToken parts =
   let { FullParts.owner = owner; repo = repo } = parts
   let baseRev = Revision.GetSha parts.baseRevision
   let headRev = Revision.GetSha parts.headRevision
 
-  let isBaseRev c = c.sha.StartsWith baseRev
-  let isPullMerge c = c.commit.message.StartsWith "Merge pull request #"
+  let isBaseRev (c: CommitListOuterObj) = c.sha.StartsWith baseRev
+  let isPullMerge (c: CommitListOuterObj) = c.commit.message.StartsWith "Merge pull request #"
 
-  sprintf "https://api.github.com/repos/%s/%s/commits?sha=%s&page=1&per_page=%u" owner repo headRev _perPage
+  sprintf "https://api.github.com/repos/%s/%s/commits?sha=%s&page=1&per_page=%u" owner repo headRev perPage
   |> Uri
-  |> _getPaginated oauthToken
+  |> getPaginated oauthToken
   |> AsyncSeq.takeWhileInclusive (not << (List.exists isBaseRev))
   |> AsyncSeq.map (fun commits ->
       commits
@@ -118,10 +25,6 @@ let getAllPrMergeCommitsInRange oauthToken parts =
       |> List.filter isPullMerge
   )
   |> AsyncSeq.filter (not << List.isEmpty)
-
-type HasSha = { sha: string }
-type BranchResp = { commit: HasSha }
-type TagResp = { object: HasSha }
 
 /// This method tries to resolve some type of revision using `rawRevisionName`.
 ///
@@ -138,7 +41,7 @@ let disambiguateAsync oauthToken owner repo rawRevisionName =
   // on the HTTP requests in here.
   let tryShowCommitAsync () = task {
     let uri = Uri <| sprintf "https://api.github.com/repos/%s/%s/commits/%s" owner repo rawRevisionName
-    let! objOpt = uri |> _tryGetAsync<HasSha> oauthToken
+    let! objOpt = uri |> tryGetAsync<HasSha> oauthToken
 
     return
       objOpt
@@ -146,7 +49,7 @@ let disambiguateAsync oauthToken owner repo rawRevisionName =
   }
   let tryShowTagAsync () = task {
     let uri = Uri <| sprintf "https://api.github.com/repos/%s/%s/git/refs/tags/%s" owner repo rawRevisionName
-    let! objOpt = uri |> _tryGetAsync<TagResp> oauthToken
+    let! objOpt = uri |> tryGetAsync<TagResp> oauthToken
 
     return
       objOpt
@@ -154,7 +57,7 @@ let disambiguateAsync oauthToken owner repo rawRevisionName =
   }
   let tryShowBranchAsync () = task {
     let uri = Uri <| sprintf "https://api.github.com/repos/%s/%s/branches/%s" owner repo rawRevisionName
-    let! objOpt = uri |> _tryGetAsync<BranchResp> oauthToken
+    let! objOpt = uri |> tryGetAsync<BranchResp> oauthToken
 
     return
       objOpt

--- a/src/WhatDid/GitHub/Http.fs
+++ b/src/WhatDid/GitHub/Http.fs
@@ -1,0 +1,166 @@
+module GitHub.Http
+
+open FSharp.Control
+open FSharp.Control.Tasks.V2.ContextInsensitive
+open Newtonsoft.Json
+open Types
+open System
+open System.Net.Http
+open System.Net.Http.Headers
+open System.Threading.Tasks
+open System.Collections.Concurrent
+open System.Net
+
+let (|Http2xx|_|) (response: HttpResponseMessage) =
+  let statusCode = int response.StatusCode
+  if 200 <= statusCode && statusCode < 300 then Some (response.StatusCode)
+  else
+    None
+let (|Http304|_|) (response: HttpResponseMessage) =
+  if (int response.StatusCode) = 304 then Some (response.StatusCode)
+  else
+    None
+
+module Cache =
+  let dict = ConcurrentDictionary<Uri, DateTimeOffset * string> ()
+  let tryGet uri =
+    let mutable value = (DateTimeOffset.MinValue, null)
+    if dict.TryGetValue (uri, &value)
+    then Some value
+    else None
+  let addOrUpdate (uri: Uri) ((lastModified', _) as value') =
+    dict.AddOrUpdate (
+      uri,
+      value',
+      (fun _ (lastModified, _ as value) ->
+        if lastModified' > lastModified then value'
+        else value
+      )
+    )
+    |> ignore
+
+  let tryRead uri (req: HttpRequestMessage) =
+    uri
+    |> tryGet
+    |> Option.map (fun (lastModified, json) ->
+        req.Headers.IfModifiedSince <- Nullable<DateTimeOffset> lastModified
+        json
+    )
+  let tryWrite uri json (resp: HttpResponseMessage) =
+    resp.Content.Headers.LastModified
+    |> Option.ofNullable
+    |> Option.iter (fun lastModified -> addOrUpdate uri (lastModified, json))
+
+let client =
+  let c = new HttpClient()
+  c.DefaultRequestHeaders.Add ("User-Agent", "whatdid")
+  c.DefaultRequestHeaders.Add ("Accept", "application/vnd.github.v3+json")
+  c
+
+let perPage = 100
+
+let createGet oauthToken (uri: Uri) =
+  let req = new HttpRequestMessage (HttpMethod.Get, uri)
+  oauthToken |> Option.iter (fun token -> req.Headers.Add ("Authorization", sprintf "token %s" token))
+  req
+
+let sendAsync request =
+  client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead)
+
+let private _deserialize<'a> = JsonConvert.DeserializeObject<'a>
+
+let deserializeAsJsonAsync<'a> (response: HttpResponseMessage) =
+  task {
+    let! json = response.Content.ReadAsStringAsync ()
+    return _deserialize<'a> json
+  }
+
+let tryGetAsync<'a> oauthToken uri =
+  task {
+    printfn "GET %A" uri
+    use req = createGet oauthToken uri
+    let cachedJson = Cache.tryRead uri req
+    use! response = sendAsync req
+
+    match response with
+    | Http2xx _ ->
+        let! json = response.Content.ReadAsStringAsync ()
+        let item = _deserialize<'a> json
+
+        Cache.tryWrite uri json response
+
+        return Some item
+
+    | Http304 status ->
+        printfn "HTTP %i (GET %A)" (int status) uri
+        return cachedJson |> Option.map _deserialize
+
+    | _ ->
+        eprintfn "WARNING: tryGetAsync: HTTP %i (GET %A)" (int response.StatusCode) uri
+        return None
+  }
+
+module Pagination =
+  let private _tryGetLink (headers: HttpResponseHeaders) =
+    let mutable values: System.Collections.Generic.IEnumerable<string> = null
+    if headers.TryGetValues ("Link", &values)
+    then Some values
+    else None
+  /// From GitHub docs (https://developer.github.com/v3/#pagination):
+  ///
+  /// Link: <https://api.github.com/resource?page=2>; rel="next",
+  ///       <https://api.github.com/resource?page=5>; rel="last"
+  let tryGetNextUrl (headers: HttpResponseHeaders) : Uri option =
+    headers
+    |> _tryGetLink
+    |> Option.bind (fun values ->
+        values
+        |> Seq.exactlyOne
+        |> fun str -> str.Split (',', StringSplitOptions.RemoveEmptyEntries)
+        |> Seq.map (fun str -> str.Trim ())
+        |> Seq.tryFind (fun str -> str.EndsWith "rel=\"next\"")
+        |> Option.map (fun str ->
+            str
+            |> Seq.skipWhile (fun ch -> ch = '<')
+            |> Seq.takeWhile (fun ch -> ch <> '>')
+            |> Seq.toArray
+            |> String
+            |> Uri
+        )
+    )
+
+  let getPaginated (reqF: Uri -> HttpRequestMessage) (deserialize: string -> 'a list) initialUri =
+    initialUri
+    |> Some
+    |> AsyncSeq.unfoldAsync (
+        function
+        | None -> async { return None }
+        | Some (uri: Uri) ->
+            task {
+              use req = reqF uri
+              printfn "%s %A" req.Method.Method uri
+              let cachedJson = Cache.tryRead uri req
+              use! response = sendAsync req
+
+              match response with
+              | Http2xx _ ->
+                  let! json = response.Content.ReadAsStringAsync ()
+                  let items = deserialize json
+                  Cache.tryWrite uri json response
+                  return Some (items, tryGetNextUrl response.Headers)
+
+              | Http304 status ->
+                  printfn "HTTP %i (GET %A)" (int status) uri
+                  return
+                    cachedJson
+                    |> Option.map (fun json -> (deserialize json, tryGetNextUrl response.Headers))
+
+              | _ ->
+                  eprintfn "WARNING: getPaginated: HTTP %i (GET %A)" (int response.StatusCode) uri
+                  return None
+            }
+            |> Async.AwaitTask
+     )
+
+let getPaginated<'a> oauthToken =
+  Pagination.getPaginated (createGet oauthToken) _deserialize<'a list>

--- a/src/WhatDid/GitHub/Types.fs
+++ b/src/WhatDid/GitHub/Types.fs
@@ -1,0 +1,8 @@
+module GitHub.Types
+
+type CommitListNestedObj = { message: string }
+type CommitListOuterObj = { sha: string; commit: CommitListNestedObj }
+
+type HasSha = { sha: string }
+type BranchResp = { commit: HasSha }
+type TagResp = { object: HasSha }

--- a/src/WhatDid/Router.fs
+++ b/src/WhatDid/Router.fs
@@ -58,7 +58,7 @@ module TempHandler =
                   headRevision = headRev }
         }
     | _ ->
-        raise <| failMissingPieces rawParts
+        raise (notFullExn rawParts)
 
   let private _getPRsAsync oauthToken (parts: FullParts) =
     match oauthToken with

--- a/src/WhatDid/Router.fs
+++ b/src/WhatDid/Router.fs
@@ -11,6 +11,7 @@ open Saturn
 open System
 open System.Threading.Tasks
 open Types
+open Types.Temp
 
 let browser = pipeline {
   plug (requireHttps true)
@@ -38,12 +39,10 @@ module TempHandler =
     |> String
     |> Int32.Parse
 
-  open GitHub.Temp
-
   let private _disambiguatePartsAsync oauthToken (rawParts: RawParts) =
     match rawParts with
     | HasEverything (owner, repo, baseRev, headRev) ->
-        let disambiguateAsync = GitHub.disambiguateAsync oauthToken owner repo
+        let disambiguateAsync = GitHub.Client.disambiguateAsync oauthToken owner repo
         task {
           let! uBaseOpt = disambiguateAsync baseRev
           let! uHeadOpt = disambiguateAsync headRev
@@ -68,7 +67,7 @@ module TempHandler =
         async {
           let! prs =
             parts
-            |> GitHub.getAllPrMergeCommitsInRange (Some oauthToken)
+            |> GitHub.Client.getAllPrMergeCommitsInRange (Some oauthToken)
             |> AsyncSeq.toBlockingSeq
             |> Seq.collect id
             |> Seq.map (fun x ->

--- a/src/WhatDid/Router.fs
+++ b/src/WhatDid/Router.fs
@@ -41,7 +41,7 @@ module TempHandler =
 
   let private _disambiguatePartsAsync oauthToken (rawParts: RawParts) =
     match rawParts with
-    | HasEverything (owner, repo, baseRev, headRev) ->
+    | Full (owner, repo, baseRev, headRev) ->
         let disambiguateAsync = GitHub.Client.disambiguateAsync oauthToken owner repo
         task {
           let! uBaseOpt = disambiguateAsync baseRev

--- a/src/WhatDid/Types.fs
+++ b/src/WhatDid/Types.fs
@@ -41,3 +41,15 @@ type FullParts = {
   baseRevision: Revision
   headRevision: Revision
 }
+
+module Temp =
+  let (|HasEverything|_|) (parts: RawParts) =
+    match parts with
+    | { owner = Some owner
+        repo = Some repo
+        baseRev = Some baseRev
+        headRev = Some headRev } -> Some (owner, repo, baseRev, headRev)
+    | _ -> None
+  let failMissingPieces (parts: RawParts) =
+    eprintfn "WARNING: Must have values for owner, repo, baseRev, headRev. %A" parts
+    exn "FIXME"

--- a/src/WhatDid/Types.fs
+++ b/src/WhatDid/Types.fs
@@ -50,6 +50,7 @@ module Temp =
         baseRev = Some baseRev
         headRev = Some headRev } -> Some (owner, repo, baseRev, headRev)
     | _ -> None
-  let failMissingPieces (parts: RawParts) =
-    eprintfn "WARNING: Must have values for owner, repo, baseRev, headRev. %A" parts
-    exn "FIXME"
+  let notFullExn (parts: RawParts) =
+    let message = sprintf "WARNING: Must have values for owner, repo, baseRev, headRev. %A" parts
+    eprintfn "%s" message
+    exn message

--- a/src/WhatDid/Types.fs
+++ b/src/WhatDid/Types.fs
@@ -43,7 +43,7 @@ type FullParts = {
 }
 
 module Temp =
-  let (|HasEverything|_|) (parts: RawParts) =
+  let (|Full|_|) (parts: RawParts) =
     match parts with
     | { owner = Some owner
         repo = Some repo

--- a/src/WhatDid/WhatDid.fsproj
+++ b/src/WhatDid/WhatDid.fsproj
@@ -11,9 +11,14 @@
     <Compile Include="Templates/Views.fs" />
     <Compile Include="Templates/NotFound.fs" />
     <Compile Include="Templates/InternalError.fs" />
+
     <Compile Include="HttpHandlers.fs" />
     <Compile Include="Envars.fs" />
     <Compile Include="Config.fs" />
+
+    <Compile Include="GitHub/Types.fs" />
+    <Compile Include="GitHub/Http.fs" />
+
     <Compile Include="GitHub.fs" />
     <Compile Include="Router.fs" />
     <Compile Include="Program.fs" />


### PR DESCRIPTION
For `GET` requests to GitHub, cache response body w/ `Last-Modified` header, send on subsequent requests to same URL w/ `If-Modified-Since` in hopes of getting a `304 Unmodified`.

Currently just uses an in-memory `ConcurrentDictionary` for cache backend, may look into using redis instead.